### PR TITLE
Scales the endgame score by the number of pawns.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -796,6 +796,11 @@ Value Eval::evaluate(const Position& pos) {
           sf = ei.pi->pawn_span(strongSide) ? ScaleFactor(56) : ScaleFactor(38);
   }
 
+  // Scale endgame by number of pawns
+  int p = pos.count<PAWN>(WHITE) + pos.count<PAWN>(BLACK);
+  int v_eg = 1 + abs(int(eg_value(score)));
+  sf = ScaleFactor(std::max(sf / 2, sf - 7 * SCALE_FACTOR_NORMAL * (14 - p) / v_eg));
+
   // Interpolate between a middlegame and a (scaled by 'sf') endgame score
   Value v =  mg_value(score) * int(me->game_phase())
            + eg_value(score) * int(PHASE_MIDGAME - me->game_phase()) * sf / SCALE_FACTOR_NORMAL;


### PR DESCRIPTION
Credits goes also to Stephane Nicolet for his great idea of scaling by pawns.

STC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 9994 W: 1929 L: 1760 D: 6305

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 11240 W: 1789 L: 1626 D: 7825

bench 7298564

Resolves #423
