### PR TITLE
Introduce new Threats weights = {350, 256}

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -107,10 +107,10 @@ namespace {
 
 
   // Evaluation weights, indexed by the corresponding evaluation term
-  enum { Mobility, PawnStructure, PassedPawns, Space, KingSafety };
+  enum { Mobility, PawnStructure, PassedPawns, Space, KingSafety, Threats };
 
   const struct Weight { int mg, eg; } Weights[] = {
-    {289, 344}, {233, 201}, {221, 273}, {46, 0}, {322, 0}
+    {289, 344}, {233, 201}, {221, 273}, {46, 0}, {322, 0}, {350, 256}
   };
 
   Score operator*(Score s, const Weight& w) {
@@ -566,9 +566,9 @@ namespace {
         score += popcount<Max15>(b) * PawnAttackThreat;
 
     if (DoTrace)
-        Trace::add(THREAT, Us, score);
+        Trace::add(THREAT, Us, score * Weights[Threats]);
 
-    return score;
+    return score * Weights[Threats];
   }
 
 


### PR DESCRIPTION
Raise the midgame threats weight by 37%.

Passed STC:
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 8165 W: 1675 L: 1487 D: 5003

and LTC:
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 28181 W: 4141 L: 3912 D: 20128

Bench: 7824961

Resolves #512
