### PR TITLE
rotating symmetric patterns with increasing skipsize

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -353,6 +353,33 @@ void MainThread::search() {
   std::cout << sync_endl;
 }
 
+const int halfDensityMap[][9] =
+{
+    {2, 0, 1},
+    {2, 1, 0},
+
+    {4, 0, 0, 1, 1},
+    {4, 0, 1, 1, 0},
+    {4, 1, 1, 0, 0},
+    {4, 1, 0, 0, 1},
+
+    {6, 0, 0, 0, 1, 1, 1},
+    {6, 0, 0, 1, 1, 1, 0},
+    {6, 0, 1, 1, 1, 0, 0},
+    {6, 1, 1, 1, 0, 0, 0},
+    {6, 1, 1, 0, 0, 0, 1},
+    {6, 1, 0, 0, 0, 1, 1},
+
+    {8, 0, 0, 0, 0, 1, 1, 1, 1},
+    {8, 0, 0, 0, 1, 1, 1, 1, 0},
+    {8, 0, 0, 1, 1, 1, 1, 0 ,0},
+    {8, 0, 1, 1, 1, 1, 0, 0 ,0},
+    {8, 1, 1, 1, 1, 0, 0, 0 ,0},
+    {8, 1, 1, 1, 0, 0, 0, 0 ,1},
+    {8, 1, 1, 0, 0, 0, 0, 1 ,1},
+    {8, 1, 0, 0, 0, 0, 1, 1 ,1},
+};
+
 
 // Thread::search() is the main iterative deepening loop. It calls search()
 // repeatedly with increasing depth until the allocated thinking time has been
@@ -394,27 +421,12 @@ void Thread::search() {
   while (++rootDepth < DEPTH_MAX && !Signals.stop && (!Limits.depth || rootDepth <= Limits.depth))
   {
       // Set up the new depths for the helper threads skipping on average every
-      // 2nd ply (using a half-density map similar to a Hadamard matrix).
+      // 2nd ply (using a half-density matrix).
       if (!mainThread)
       {
-          int d = rootDepth + rootPos.game_ply();
-
-          if (idx <= 6 || idx > 24)
-          {
-              if (((d + idx) >> (msb(idx + 1) - 1)) % 2)
-                  continue;
-          }
-          else
-          {
-              // Table of values of 6 bits with 3 of them set
-              static const int HalfDensityMap[] = {
-                0x07, 0x0b, 0x0d, 0x0e, 0x13, 0x16, 0x19, 0x1a, 0x1c,
-                0x23, 0x25, 0x26, 0x29, 0x2c, 0x31, 0x32, 0x34, 0x38
-              };
-
-              if ((HalfDensityMap[idx - 7] >> (d % 6)) & 1)
-                  continue;
-          }
+          int row = (idx - 1) % 20;
+          if (halfDensityMap[row][(rootDepth + rootPos.game_ply()) % halfDensityMap[row][0] + 1])
+             continue;
       }
 
       // Age out PV variability metric


### PR DESCRIPTION
STC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00] sprt @ 5+0.1 th 21
Total: 7068 W: 1121 L: 975 D: 4972

LTC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00] sprt @ 12+0.12 th 21
Total: 26691 W: 3594 L: 3481 D: 19616

No functional change with a single thread

Resolves #574
