### PR TITLE
Simplify TT penalty stat (#980)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -657,7 +657,7 @@ namespace {
                     update_cm_stats(ss-1, pos.piece_on(prevSq), prevSq, -stat_bonus(depth + ONE_PLY));
             }
             // Penalty for a quiet ttMove that fails low
-            else if (ttValue < alpha && !pos.capture_or_promotion(ttMove))
+            else if (!pos.capture_or_promotion(ttMove))
             {
                 Value penalty = -stat_bonus(depth + ONE_PLY);
                 thisThread->history.update(pos.side_to_move(), ttMove, penalty);


### PR DESCRIPTION
STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 20251 W: 3692 L: 3570 D: 12989

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 16432 W: 2155 L: 2029 D: 12248

Bench: 5941174