### PR TITLE
Skip quiet moves based on moveCount pruning threshold and history stats

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -175,7 +175,7 @@ void MovePicker::score<EVASIONS>() {
 /// left. It picks the move with the biggest value from a list of generated moves
 /// taking care not to return the ttMove if it has already been searched.
 
-Move MovePicker::next_move() {
+Move MovePicker::next_move(bool skipQuiets) {
 
   Move move;
 
@@ -248,9 +248,11 @@ Move MovePicker::next_move() {
       ++stage;
 
   case QUIET:
-      while (cur < endMoves)
+      while (    cur < endMoves
+             && (!skipQuiets || cur->value >= VALUE_ZERO))
       {
           move = *cur++;
+
           if (   move != ttMove
               && move != ss->killers[0]
               && move != ss->killers[1]

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -95,7 +95,7 @@ public:
   MovePicker(const Position&, Move, Depth, Square);
   MovePicker(const Position&, Move, Depth, Search::Stack*);
 
-  Move next_move();
+  Move next_move(bool skipQuiets = false);
 
 private:
   template<GenType> void score();


### PR DESCRIPTION
If we can moveCountPrune and next quiet move has negative stats,
then go directly to the next move stage (Bad_Captures).

Reduction formula is tweaked to compensate for the decrease in move count that is used in LMR.

STC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 6847 W: 1276 L: 1123 D: 4448

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 48687 W: 6503 L: 6226 D: 35958

Bench: 5919519

Closes #1036