### PR TITLE
Sort moves partially: linear depth dependence.

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -242,8 +242,7 @@ Move MovePicker::next_move(bool skipQuiets) {
       endMoves = generate<QUIETS>(pos, cur);
       score<QUIETS>();
 
-      partial_insertion_sort(cur, endMoves,
-                             depth < 3 * ONE_PLY ? VALUE_ZERO : Value(INT_MIN));
+      partial_insertion_sort(cur, endMoves, Value(-4000 * depth / ONE_PLY));
       ++stage;
 
   case QUIET:


### PR DESCRIPTION
STC: http://tests.stockfishchess.org/tests/view/58f98d260ebc59035df33d5e
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 58958 W: 10862 L: 10485 D: 37611

LTC: http://tests.stockfishchess.org/tests/view/58fa45d40ebc59035df33d86
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 18607 W: 2427 L: 2251 D: 13929

Bench: 6517820