### PR TITLE
Use a fraction of king danger in endgame score

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -475,7 +475,7 @@ namespace {
 
         // Transform the kingDanger units into a Score, and substract it from the evaluation
         if (kingDanger > 0)
-            score -= make_score(kingDanger * kingDanger / 4096, 0);
+            score -= make_score(kingDanger * kingDanger / 4096, kingDanger / 16);
     }
 
     // King tropism: firstly, find squares that opponent attacks in our king flank


### PR DESCRIPTION
When SF has an attack on the opponent king in one flank, the huge
midgame -> endgame gradient of the tapered eval prevents us to properly
evaluate neutral exchanges on the other flank as the current king
danger score is a pure midgame term. This may affect SF's ability to
switch to defense in some positions. We add a small contribution
of the king danger to the endgame score to limit this
effect.

Again suggested in the following forum thread:
https://groups.google.com/forum/?fromgroups=#!topic/fishcooking/xrUCQ7b0
ObE

Passed STC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 12719 W: 2371 L: 2192 D: 8156
http://tests.stockfishchess.org/tests/view/5919761a0ebc59035df3468f

And LTC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 31293 W: 4194 L: 3974 D: 23125
http://tests.stockfishchess.org/tests/view/591980450ebc59035df34695

Bench: 5961548