### PR TITLE
Handle BxN trade as good capture when history score is good

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -182,6 +182,11 @@ Move MovePicker::next_move(bool skipQuiets) {
               if (pos.see_ge(move))
                   return move;
 
+              if (   type_of(pos.piece_on(to_sq(move))) == KNIGHT
+                  && type_of(pos.moved_piece(move)) == BISHOP
+                  && (cur-1)->value > 1090)
+                  return move;
+
               // Losing capture, move it to the beginning of the array
               *endBadCaptures++ = move;
           }


### PR DESCRIPTION
STC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 19374 W: 3499 L: 3294 D: 12581
http://tests.stockfishchess.org/tests/view/59fc23f50ebc590ccbb8a0bf

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 91030 W: 11680 L: 11274 D: 68076
http://tests.stockfishchess.org/tests/view/59fc43ad0ebc590ccbb8a0d0

Bench: 5482249