### PR TITLE
Revert "Implement old 'multipv' search"

### DIFF
--- a/src/thread.h
+++ b/src/thread.h
@@ -60,7 +60,7 @@ public:
   Pawns::Table pawnsTable;
   Material::Table materialTable;
   Endgames endgames;
-  size_t PVIdx, multiPV;
+  size_t PVIdx;
   int selDepth, nmp_ply, nmp_odd;
   std::atomic<uint64_t> nodes, tbHits;
 


### PR DESCRIPTION
This revert the following commit:
https://github.com/official-stockfish/Stockfish/commit/44a7db0f9ac02d2461aff39e25f1ac9107ffbfac

Bug report by Ronald de Man in issue:
https://github.com/official-stockfish/Stockfish/issues/1392

Bench: 5023629