### PR TITLE
Enable LTO for clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,12 @@ matrix:
       compiler: clang
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test']
-          packages: ['clang', 'g++-multilib', 'valgrind', 'expect']
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-5.0']
+          packages: ['clang-5.0', 'llvm-5.0-dev', 'g++-multilib', 'valgrind', 'expect']
       env:
-        - COMPILER=clang++
+        - COMPILER=clang++-5.0
         - COMP=clang
+        - LDFLAGS=-fuse-ld=gold
 
     - os: osx
       compiler: gcc

--- a/src/Makefile
+++ b/src/Makefile
@@ -302,8 +302,6 @@ ifeq ($(optimize),yes)
 
 	ifeq ($(comp),clang)
 		ifeq ($(KERNEL),Darwin)
-				CXXFLAGS += -flto
-				LDFLAGS += $(CXXFLAGS)
 			ifeq ($(arch),i386)
 				CXXFLAGS += -mdynamic-no-pic
 			endif
@@ -349,24 +347,20 @@ endif
 ### 3.8 Link Time Optimization, it works since gcc 4.5 but not on mingw under Windows.
 ### This is a mix of compile and link time options because the lto link phase
 ### needs access to the optimization flags.
-ifeq ($(comp),gcc)
-	ifeq ($(optimize),yes)
-	ifeq ($(debug),no)
+ifeq ($(optimize),yes)
+ifeq ($(debug), no)
+	ifeq ($(comp),$(filter $(comp),gcc clang))
+		CXXFLAGS += -flto
+		LDFLAGS += $(CXXFLAGS)
+	endif
+
+	ifeq ($(comp),mingw)
+	ifeq ($(KERNEL),Linux)
 		CXXFLAGS += -flto
 		LDFLAGS += $(CXXFLAGS)
 	endif
 	endif
 endif
-
-ifeq ($(comp),mingw)
-	ifeq ($(KERNEL),Linux)
-	ifeq ($(optimize),yes)
-	ifeq ($(debug),no)
-		CXXFLAGS += -flto
-		LDFLAGS += $(CXXFLAGS)
-	endif
-	endif
-	endif
 endif
 
 ### 3.9 Android 5 can only run position independent executables. Note that this


### PR DESCRIPTION
Enable link-time optimization in the Makefile when compiling with clang.
Also update travis.yml to use clang++-5.0 and llvm-5.0-dev.

No functional change.