### PR TITLE
Using a S-curve for the optimism measure

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,7 +59,7 @@ Jerry Donald Watson (jerrydonaldwatson)
 Jonathan Calovski (Mysseno)
 Joost VandeVondele (vondele)
 Jörg Oster (joergoster)
-Joseph Hellis (jhellis3)
+Joseph Ellis (jhellis3)
 Joseph R. Prostko
 jundery
 Justin Blanchard

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -346,11 +346,13 @@ void Thread::search() {
               alpha = std::max(rootMoves[PVIdx].previousScore - delta,-VALUE_INFINITE);
               beta  = std::min(rootMoves[PVIdx].previousScore + delta, VALUE_INFINITE);
 
-              // Adjust contempt based on current bestValue
-              ct =  Options["Contempt"] * PawnValueEg / 100 // From centipawns
-                  + (bestValue >  500 ?  50:                // Dynamic contempt
-                     bestValue < -500 ? -50:
-                     bestValue / 10);
+              ct =  Options["Contempt"] * PawnValueEg / 100; // From centipawns
+
+              // Adjust contempt based on current bestValue (dynamic contempt)
+              int sign = (bestValue > 0) - (bestValue < 0);
+              ct +=  bestValue >  500 ?  70 :
+                     bestValue < -500 ? -70 :
+                     bestValue / 10 + sign * int(std::round(3.22 * log(1 + abs(bestValue))));
 
               Eval::Contempt = (us == WHITE ?  make_score(ct, ct / 2)
                                             : -make_score(ct, ct / 2));

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -59,7 +59,7 @@ void init(OptionsMap& o) {
   const int MaxHashMB = Is64Bit ? 131072 : 2048;
 
   o["Debug Log File"]        << Option("", on_logger);
-  o["Contempt"]              << Option(18, -100, 100);
+  o["Contempt"]              << Option(12, -100, 100);
   o["Threads"]               << Option(1, 1, 512, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);


### PR DESCRIPTION
Add a logarithmic term in the optimism computation, increase
the maximal optimism and lower the contempt offset.

This increases the dynamics of the optimism aspects, giving
a boost for balanced positions without skewing too much on
unbalanced positions (but this version will enter panic mode
faster than previous master when behind, trying to draw faster
when slightly behind). This helps, since optimism is in general
a good thing, for instance at LTC, but too high optimism
rapidly contaminates play.

passed STC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 159343 W: 34489 L: 33588 D: 91266
http://tests.stockfishchess.org/tests/view/5a8db9340ebc590297cc85b6

passed LTC:
LLR: 2.97 (-2.94,2.94) [0.00,5.00]
Total: 47491 W: 7825 L: 7517 D: 32149
http://tests.stockfishchess.org/tests/view/5a9456a80ebc590297cc8a89

It must be mentioned that a version of the PR with contempt 0
did not pass STC [0,5]. The version in the patch, which uses
default contempt 12, was found to be as strong as current master
on different matches against SF7 and SF8, both at STC and LTC.

One drawback maybe is that it raises the draw rate in self-play
from 56% to 59%, giving a little bit less sensitivity for SF
developpers to find evaluation improvements by selfplay tests
in fishtest.

Possible further work:

• tune the values accurately, while keeping in mind the drawrate issue
• check whether it is possible to remove linear and offset term
• try to simplify the S-shape curve

Bench: 5934644