### PR TITLE
IID margin reduced to 128

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -791,7 +791,7 @@ namespace {
     // Step 11. Internal iterative deepening (skipped when in check)
     if (    depth >= 6 * ONE_PLY
         && !ttMove
-        && (PvNode || ss->staticEval + 256 >= beta))
+        && (PvNode || ss->staticEval + 128 >= beta))
     {
         Depth d = 3 * depth / 4 - 2 * ONE_PLY;
         search<NT>(pos, ss, alpha, beta, d, cutNode, true);


### PR DESCRIPTION
Change the internal iterative deepening margin from +256 to +128.

Passed STC:
LLR: 3.26 (-2.94,2.94) [0.00,5.00]
Total: 22006 W: 4646 L: 4400 D: 12960
http://tests.stockfishchess.org/tests/view/5ab54a240ebc590295d8847d

Passed LTC:
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 46665 W: 7187 L: 6898 D: 32580
http://tests.stockfishchess.org/tests/view/5ab5ba690ebc590295d884b4

Possible work in this area after this change:

• Reduce even more the margin?
• Try to do IID for smaller depths too?

Bench: 5851102