### PR TITLE
Introduce Overload

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -77,6 +77,7 @@ Lucas Braesch (lucasart)
 Lyudmil Antonov (lantonov)
 Matthew Lai (matthewlai)
 Matthew Sullivan
+Mark Tenzer (31m059)
 Michael Byrne (MichaelB7)
 Michael Stembera (mstembera)
 Michel Van den Bergh (vdbergh)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -171,6 +171,7 @@ namespace {
   constexpr Score KnightOnQueen      = S( 21, 11);
   constexpr Score LongDiagonalBishop = S( 22,  0);
   constexpr Score MinorBehindPawn    = S( 16,  0);
+  constexpr Score Overload           = S( 10,  5);
   constexpr Score PawnlessFlank      = S( 20, 80);
   constexpr Score RookOnPawn         = S(  8, 24);
   constexpr Score SliderOnQueen      = S( 42, 21);
@@ -520,7 +521,7 @@ namespace {
     Bitboard b, weak, defended, nonPawnEnemies, stronglyProtected, safeThreats;
     Score score = SCORE_ZERO;
 
-    // Non-pawn enemies attacked by a pawn
+    // Non-pawn enemies
     nonPawnEnemies = pos.pieces(Them) ^ pos.pieces(Them, PAWN);
 
     // Our safe or protected pawns
@@ -607,6 +608,12 @@ namespace {
     // Connectivity: ensure that knights, bishops, rooks, and queens are protected
     b = (pos.pieces(Us) ^ pos.pieces(Us, PAWN, KING)) & attackedBy[Us][ALL_PIECES];
     score += Connectivity * popcount(b);
+
+    // Bonus for overload (non-pawn enemies attacked and defended exactly once)
+    b =  nonPawnEnemies
+       & attackedBy[Us][ALL_PIECES]   & ~attackedBy2[Us]
+       & attackedBy[Them][ALL_PIECES] & ~attackedBy2[Them];
+    score += Overload * popcount(b);
 
     if (T)
         Trace::add(THREAT, Us, score);


### PR DESCRIPTION
This patch applies a S(10, 5) bonus for every square that is:

- Occupied by an enemy piece which is not a pawn
- Attacked exactly once by our pieces
- Defended exactly once by enemy pieces

The idea is that these pieces must be defended. Their defenders have
dramatically limited mobility, and they are vulnerable to our future
attack.

As with connectivity, there are probably many more tests to be run in
this area. In particular:

- I believe @snicolet's queen overload tests have demonstrated a potential
  need for a queen overload bonus above and beyond this one; however, the
  conditions for "overload" in this patch are different (excluding pieces
  we attack twice).  My next test after this is (hopefully) merged will be
  to intersect the Bitboard I define here with the enemy's queen attacks and
  attempt to give additional bonus.
- Perhaps we should exclude pieces attacked by pawns--can pawns really be
  overloaded? Should they have the same weight, or less?  This didn't work
  with a previous version, but it could work with this one.
- More generally, different pieces may need more or less bonus. We could
  change bonuses based on what type of enemy piece is being overloaded, what
  type of friendly piece is attacking, and/or what type of piece is being
  defended by the overloaded piece and attacked by us, or any intersection
  of these three.  For example, here attacked/defended pawns are excluded,
  but they're not totally worthless targets, and could be added again with
  a smaller bonus.
- This list is by no means exhaustive.

STC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 17439 W: 3599 L: 3390 D: 10450
http://tests.stockfishchess.org/tests/view/5ac78a2e0ebc59435923735e

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 43304 W: 6533 L: 6256 D: 30515
http://tests.stockfishchess.org/tests/view/5ac7a1d80ebc59435923736f

Closes https://github.com/official-stockfish/Stockfish/pull/1533

Bench: 5248871

----------------

This is my first time opening a PR, so I apologize if there are errors.
There are too many people to thank since I submitted my first test just
over a month ago. Thank you all for the warm welcome and here is to more
green patches!

In particular, I would like to thank:
- @crossbr, whose comment in a FishCooking thread first inspired me to
            consider the overloading of pieces other than queens,
- @snicolet, whose queen overload tests inspired this one and served as
             the base of my first overload attempts,
- @protonspring, whose connectivity tests inspired this one and who provided
                 much of the feedback needed to take this from red to green,
- @vondele, who kindly corrected me when I submitted a bad LTC test,
- @Rocky640, who has helped me over and over again in the past month.

Thank you all!