### PR TITLE
Tweak opposite colord bishops endgame scaling.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -795,9 +795,10 @@ namespace {
         if (   pos.opposite_bishops()
             && pos.non_pawn_material(WHITE) == BishopValueMg
             && pos.non_pawn_material(BLACK) == BishopValueMg)
-            sf = 31;
+            sf = 8 + 4 * pe->pawn_asymmetry();
         else
             sf = std::min(40 + (pos.opposite_bishops() ? 2 : 7) * pos.count<PAWN>(strongSide), sf);
+
     }
 
     return ScaleFactor(sf);


### PR DESCRIPTION
Make scale factor dependant on asymmetry of pawn structure.

STC http://tests.stockfishchess.org/tests/view/5b92a2a80ebc592cf2753dd4
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 31490 W: 6870 L: 6587 D: 18033

LTC http://tests.stockfishchess.org/tests/view/5b92f8170ebc592cf2754438
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 54928 W: 8988 L: 8653 D: 37287

This patch shows that SF can use some more complicated endgame heuristics to evaluate endgames better from the distance.

Closes https://github.com/official-stockfish/Stockfish/pull/1767

Bench: 4248710