### PR TITLE
Simplify mobility danger

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -480,15 +480,12 @@ namespace {
                      +   4 * tropism
                      - 873 * !pos.count<QUEEN>(Them)
                      -   6 * mg_value(score) / 8
+                     +       mg_value(mobility[Them] - mobility[Us])
                      -   30;
 
         // Transform the kingDanger units into a Score, and subtract it from the evaluation
         if (kingDanger > 0)
-        {
-            int mobilityDanger = mg_value(mobility[Them] - mobility[Us]);
-            kingDanger = std::max(0, kingDanger + mobilityDanger);
             score -= make_score(kingDanger * kingDanger / 4096, kingDanger / 16);
-        }
     }
 
     // Penalty when our king is on a pawnless flank


### PR DESCRIPTION
Check sign only after adding mobility danger term.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 9090 W: 2001 L: 1856 D: 5233
http://tests.stockfishchess.org/tests/view/5bdc5ee10ebc595e0ae27bc2

LTC
LLR: 2.94 (-2.94,2.94) [-3.00,1.00]
Total: 123466 W: 19766 L: 19805 D: 83895
http://tests.stockfishchess.org/tests/view/5bdc678e0ebc595e0ae27cf3

bench: 3630207