### PR TITLE
Simplify TrappedRook

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -168,7 +168,7 @@ namespace {
   constexpr Score ThreatByPawnPush   = S( 48, 39);
   constexpr Score ThreatByRank       = S( 13,  0);
   constexpr Score ThreatBySafePawn   = S(173, 94);
-  constexpr Score TrappedRook        = S( 96,  4);
+  constexpr Score TrappedRook        = S( 47,  4);
   constexpr Score WeakQueen          = S( 49, 15);
   constexpr Score WeakUnopposedPawn  = S( 12, 23);
 
@@ -377,7 +377,7 @@ namespace {
             {
                 File kf = file_of(pos.square<KING>(Us));
                 if ((kf < FILE_E) == (file_of(s) < kf))
-                    score -= (TrappedRook - make_score(mob * 22, 0)) * (1 + !pos.castling_rights(Us));
+                    score -= TrappedRook * (1 + !pos.castling_rights(Us));
             }
         }
 


### PR DESCRIPTION
Simplified TrappedRook to a single penalty removing the dependency on mobility.

STC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 106718 W: 23530 L: 23577 D: 59611
http://tests.stockfishchess.org/tests/view/5c43f6bd0ebc5902bb5d4131

LTC
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 54053 W: 8890 L: 8822 D: 36341
http://tests.stockfishchess.org/tests/view/5c44932a0ebc5902bb5d4d59

bench 3665090