### PR TITLE
Revert "Shuffle detection #2064"

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -607,15 +607,6 @@ namespace {
             : ttHit    ? tte->move() : MOVE_NONE;
     ttPv = (ttHit && tte->is_pv()) || (PvNode && depth > 4 * ONE_PLY);
 
-    // if position has been searched at higher depths and we are shuffling, return value_draw
-    if (pos.rule50_count() > 36
-        && ss->ply > 36
-        && depth < 3 * ONE_PLY
-        && ttHit
-        && tte->depth() > depth
-        && pos.count<PAWN>() > 0)
-        return VALUE_DRAW;
-
     // At non-PV nodes we check for an early TT cutoff
     if (  !PvNode
         && ttHit
@@ -932,10 +923,6 @@ moves_loop: // When in check, search starts from here
       // Check extension (~2 Elo)
       else if (    givesCheck
                && (pos.blockers_for_king(~us) & from_sq(move) || pos.see_ge(move)))
-          extension = ONE_PLY;
-
-      // Shuffle extension
-      else if(pos.rule50_count() > 14 && ss->ply > 14 && depth < 3 * ONE_PLY && PvNode)
           extension = ONE_PLY;
 
       // Castling extension


### PR DESCRIPTION
It causes a serious regression hanging a simple fixed
depth search. Reproducible with:

position fen q1B5/1P1q4/8/8/8/6R1/8/1K1k4 w - - 0 1
go depth 13

The reason is a search tree explosion due to:

if (... && depth < 3 * ONE_PLY)
      extension = ONE_PLY;

This is very dangerous code by itself because triggers **at the leafs**
and in the above position keeps extending endlessly. In normal games
time deadline makes the search to stop sooner or later, but in fixed
seacrch we just hang possibly for a very long time. This is not acceptable
because 'go depth 13' shall not be a surprise for any position.

This patch reverts commit 76f1807baa90eb69f66001d25df2a28533f9406f.
and fixes the issue https://github.com/official-stockfish/Stockfish/issues/2091

Bench: 3243738