### PR TITLE
Stat Score reset at rootNode - Bench: 3393330 (#2124)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -594,7 +594,10 @@ namespace {
     // starts with statScore = 0. Later grandchildren start with the last calculated
     // statScore of the previous grandchild. This influences the reduction rules in
     // LMR which are based on the statScore of parent position.
-    (ss+2)->statScore = 0;
+	if (rootNode)
+		(ss + 4)->statScore = 0;
+	else
+		(ss + 2)->statScore = 0;
 
     // Step 4. Transposition table lookup. We don't want the score of a partial
     // search to overwrite a previous full search TT value, so we use a different


### PR DESCRIPTION
At rootNode reset great great grandchildren stat score i.e (ss + 4)->statScore = 0

STC: (yellow)
LLR: -2.96 (-2.94,2.94) [0.50,4.50]
Total: 256079 W: 57423 L: 56315 D: 142341
http://tests.stockfishchess.org/tests/view/5ccb0c420ebc5925cf03a6a5

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 61550 W: 10611 L: 10260 D: 40679
http://tests.stockfishchess.org/tests/view/5ccbf9d00ebc5925cf03c487

Bench: 3393330