### PR TITLE
less bonus for blocked connected pawn

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -138,7 +138,7 @@ namespace {
         // Score this pawn
         if (support | phalanx)
         {
-            int v =  Connected[r] * (2 + bool(phalanx) - bool(opposed))
+            int v =  Connected[r] * (4 + 2 * bool(phalanx) - 2 * bool(opposed) - bool(blocked)) / 2
                    + 21 * popcount(support);
 
             score += make_score(v, v * (r - 2) / 4);


### PR DESCRIPTION
Use less bonus for blocked connected pawns so closed positions are less worth.

STC:
LLR: 2.96 (-2.94,2.94) {-0.50,1.50}
Total: 60004 W: 11904 L: 11619 D: 36481
Ptnml(0-2): 1066, 7083, 13535, 7136, 1182
https://tests.stockfishchess.org/tests/view/5e941a8063d105aebbab23e3

LTC:
LLR: 2.95 (-2.94,2.94) {0.25,1.75}
Total: 36606 W: 4831 L: 4556 D: 27219
Ptnml(0-2): 252, 3353, 10872, 3520, 306
https://tests.stockfishchess.org/tests/view/5e9444b963d105aebbab2427

closes https://github.com/official-stockfish/Stockfish/pull/2629

Bench: 4961260