### PR TITLE
Penalty for all enemy pawns xrayed by our bishop.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -128,6 +128,7 @@ namespace {
 
   // Assorted bonuses and penalties
   constexpr Score BishopPawns         = S(  3,  7);
+  constexpr Score BishopXRayPawns     = S(  4,  5);
   constexpr Score CorneredBishop      = S( 50, 50);
   constexpr Score FlankAttacks        = S(  8,  0);
   constexpr Score Hanging             = S( 69, 36);
@@ -317,6 +318,9 @@ namespace {
 
                 score -= BishopPawns * pos.pawns_on_same_color_squares(Us, s)
                                      * (!(attackedBy[Us][PAWN] & s) + popcount(blocked & CenterFiles));
+
+                // Penalty for all enemy pawns x-rayed
+                score -= BishopXRayPawns * popcount(PseudoAttacks[BISHOP][s] & pos.pieces(Them, PAWN));
 
                 // Bonus for bishop on a long diagonal which can "see" both center squares
                 if (more_than_one(attacks_bb<BISHOP>(s, pos.pieces(PAWN)) & Center))


### PR DESCRIPTION
STC:
LLR: 2.93 (-2.94,2.94) {-0.50,1.50}
Total: 159760 W: 30229 L: 29813 D: 99718
Ptnml(0-2): 2659, 18309, 37534, 18713, 2665
https://tests.stockfishchess.org/tests/view/5eb1d5032326444a3b6d33ce

LTC:
LLR: 2.93 (-2.94,2.94) {0.25,1.75}
Total: 26496 W: 3908 L: 3656 D: 18932
Ptnml(0-2): 192, 2512, 7610, 2720, 214
https://tests.stockfishchess.org/tests/view/5eb1e2dd2326444a3b6d33f9

closes https://github.com/official-stockfish/Stockfish/pull/2662

Bench 5185517