### PR TITLE
Increased reduction for captures in LMR

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1151,15 +1151,15 @@ moves_loop: // When in check, search starts from here
           if (singularQuietLMR)
               r--;
 
+          // Increase reduction for cut nodes (~3 Elo)
+          if (cutNode)
+              r += 1 + !captureOrPromotion;
+
           if (!captureOrPromotion)
           {
               // Increase reduction if ttMove is a capture (~3 Elo)
               if (ttCapture)
                   r++;
-
-              // Increase reduction for cut nodes (~3 Elo)
-              if (cutNode)
-                  r += 2;
 
               ss->statScore =  thisThread->mainHistory[us][from_to(move)]
                              + (*contHist[0])[movedPiece][to_sq(move)]


### PR DESCRIPTION
It now does, in LMR, an increased on reduction by 1 for captures in cut nodes.

STC:
LLR: 2.93 (-2.94,2.94) <-0.50,2.50>
Total: 30656 W: 2565 L: 2397 D: 25694
Ptnml(0-2): 63, 2012, 11029, 2142, 82
https://tests.stockfishchess.org/tests/view/60a96733ce8ea25a3ef04178

LTC:
LLR: 2.93 (-2.94,2.94) <0.50,3.50>
Total: 124840 W: 4139 L: 3878 D: 116823
Ptnml(0-2): 48, 3480, 55100, 3747, 45
https://tests.stockfishchess.org/tests/view/60a995f5ce8ea25a3ef041b7

closes https://github.com/official-stockfish/Stockfish/pull/3494

bench: 3864295