### PR TITLE
Limit double extensions

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -52,6 +52,7 @@ struct Stack {
   bool inCheck;
   bool ttPv;
   bool ttHit;
+  int doubleExtensions;
 };
 
 


### PR DESCRIPTION
Double extensions can lead to search explosions, for specific positions.
Currently, however, these double extensions are worth about 10Elo and cannot
be removed. This patch instead limits the number of double extensions given
to a maximum of 3.

This fixes https://github.com/official-stockfish/Stockfish/issues/3532
where the following testcase was shown to be problematic:

```
uci
setoption name Hash value 4
setoption name Contempt value 0
ucinewgame
position fen 8/Pk6/8/1p6/8/P1K5/8/6B1 w - - 37 130
go depth 20
```

passed STC:
https://tests.stockfishchess.org/tests/view/60c13161457376eb8bcaaa0f
LLR: 2.95 (-2.94,2.94) <-2.50,0.50>
Total: 73256 W: 6114 L: 6062 D: 61080
Ptnml(0-2): 222, 4912, 26306, 4968, 220

passed LTC:
https://tests.stockfishchess.org/tests/view/60c196fb457376eb8bcaaa6b
LLR: 2.94 (-2.94,2.94) <-2.50,0.50>
Total: 166440 W: 5559 L: 5594 D: 155287
Ptnml(0-2): 106, 4921, 73197, 4894, 102

closes https://github.com/official-stockfish/Stockfish/pull/3544

Bench: 5067605