### PR TITLE
Allow some LMR double extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1219,13 +1219,13 @@ moves_loop: // When in check, search starts here
 
           // In general we want to cap the LMR depth search at newDepth. But if reductions
           // are really negative and movecount is low, we allow this move to be searched
-          // deeper than the first move (this may lead to hidden double extensions if
-          // newDepth got its own extension before).
-          int deeper =   r >= -1               ? 0
-                       : noLMRExtension        ? 0
-                       : moveCount <= 5        ? 1
-                       : (depth > 6 && PvNode) ? 1
-                       :                         0;
+          // deeper than the first move (this may lead to hidden double extensions).
+          int deeper =   r >= -1                   ? 0
+                       : noLMRExtension            ? 0
+                       : moveCount <= 3 && r <= -3 ? 2
+                       : moveCount <= 5            ? 1
+                       : PvNode && depth > 6       ? 1
+                       :                             0;
 
           Depth d = std::clamp(newDepth - r, 1, newDepth + deeper);
 


### PR DESCRIPTION
Allow some LMR double extensions for the second and third sons of each node.

STC:
LLR: 2.94 (-2.94,2.94) <-0.50,2.50>
Total: 170320 W: 42608 L: 42187 D: 85525
Ptnml(0-2): 516, 19635, 44422, 20086, 501
https://tests.stockfishchess.org/tests/view/616a9e3899b580bf37797cf4

LTC:
LLR: 2.93 (-2.94,2.94) <0.50,3.50>
Total: 74400 W: 18783 L: 18423 D: 37194
Ptnml(0-2): 46, 7812, 21129, 8162, 51
https://tests.stockfishchess.org/tests/view/616b378499b580bf37797d61

closes https://github.com/official-stockfish/Stockfish/pull/3742

Bench: 4877152