### PR TITLE
Tune a few NNUE related scaling parameters

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1091,9 +1091,9 @@ Value Eval::evaluate(const Position& pos) {
       v = Evaluation<NO_TRACE>(pos).value();          // classical
   else
   {
-      int scale =   883
-                  + 32 * pos.count<PAWN>()
-                  + 32 * pos.non_pawn_material() / 1024;
+      int scale =   898
+                  + 24 * pos.count<PAWN>()
+                  + 33 * pos.non_pawn_material() / 1024;
 
        v = NNUE::evaluate(pos, true) * scale / 1024;  // NNUE
 
@@ -1102,7 +1102,7 @@ Value Eval::evaluate(const Position& pos) {
   }
 
   // Damp down the evaluation linearly when shuffling
-  v = v * (100 - pos.rule50_count()) / 100;
+  v = v * (207 - pos.rule50_count()) / 207;
 
   // Guarantee evaluation does not hit the tablebase range
   v = std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);


### PR DESCRIPTION
passed STC
LLR: 2.94 (-2.94,2.94) <0.00,2.50>
Total: 102480 W: 26099 L: 25708 D: 50673
Ptnml(0-2): 282, 11637, 27003, 12044, 274
https://tests.stockfishchess.org/tests/view/618820e3d7a085ad008ef1dd

passed LTC
LLR: 2.93 (-2.94,2.94) <0.50,3.00>
Total: 165512 W: 41689 L: 41112 D: 82711
Ptnml(0-2): 82, 17255, 47510, 17822, 87
https://tests.stockfishchess.org/tests/view/6188b470d7a085ad008ef239

closes https://github.com/official-stockfish/Stockfish/pull/3784

Bench: 6339548