### PR TITLE
Update default net to nn-4f56ecfca5b7.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,7 +39,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-3678835b1d3d.nnue"
+  #define EvalFileDefaultName   "nn-4f56ecfca5b7.nnue"
 
   namespace NNUE {
 


### PR DESCRIPTION
New net trained with nnue-pytorch, started from a master net on a data set of Leela
(T60.binpack+T74.binpck) Stockfish data (wrongIsRight_nodes5000pv2.binpack), and
Michael Babigian's conversion of T60 Leela data (including TB7 rescoring) (farseer.binpack)
available as a single interleaved binpack:

https://drive.google.com/file/d/1_sQoWBl31WAxNXma2v45004CIVltytP8/view?usp=sharing

The nnue-pytorch branch used is https://github.com/vondele/nnue-pytorch/tree/wdl

passed STC:
https://tests.stockfishchess.org/tests/view/61a3cc729f0c43dae1c71f1b
LLR: 2.95 (-2.94,2.94) <0.00,2.50>
Total: 49152 W: 12842 L: 12544 D: 23766
Ptnml(0-2): 154, 5542, 12904, 5804, 172

passed LTC:
https://tests.stockfishchess.org/tests/view/61a43c6260afd064f2d724f1
LLR: 2.96 (-2.94,2.94) <0.50,3.00>
Total: 25528 W: 6676 L: 6425 D: 12427
Ptnml(0-2): 9, 2593, 7315, 2832, 15

closes https://github.com/official-stockfish/Stockfish/pull/3816

Bench: 6885242