### PR TITLE
Use NNUE in low piece endgames close to the root.

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1088,7 +1088,8 @@ Value Eval::evaluate(const Position& pos) {
   // Deciding between classical and NNUE eval (~10 Elo): for high PSQ imbalance we use classical,
   // but we switch to NNUE during long shuffling or with high material on the board.
   if (  !useNNUE
-      || abs(eg_value(pos.psq_score())) * 5 > (856 + pos.non_pawn_material() / 64) * (5 + pos.rule50_count()))
+      || ((pos.this_thread()->depth > 9 || pos.count<ALL_PIECES>() > 7) &&
+          abs(eg_value(pos.psq_score())) * 5 > (856 + pos.non_pawn_material() / 64) * (5 + pos.rule50_count())))
   {
       v = Evaluation<NO_TRACE>(pos).value();          // classical
       useClassical = abs(v) >= 297;
@@ -1138,6 +1139,7 @@ std::string Eval::trace(Position& pos) {
   std::memset(scores, 0, sizeof(scores));
 
   // Reset any global variable used in eval
+  pos.this_thread()->depth           = 0;
   pos.this_thread()->trend           = SCORE_ZERO;
   pos.this_thread()->bestValue       = VALUE_ZERO;
   pos.this_thread()->optimism[WHITE] = VALUE_ZERO;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -560,6 +560,7 @@ namespace {
 
     // Step 1. Initialize node
     Thread* thisThread = pos.this_thread();
+    thisThread->depth  = depth;
     ss->inCheck        = pos.checkers();
     priorCapture       = pos.captured_piece();
     Color us           = pos.side_to_move();

--- a/src/thread.h
+++ b/src/thread.h
@@ -69,7 +69,7 @@ public:
   Position rootPos;
   StateInfo rootState;
   Search::RootMoves rootMoves;
-  Depth rootDepth, completedDepth;
+  Depth rootDepth, completedDepth, depth;
   Value rootDelta;
   CounterMoveHistory counterMoves;
   ButterflyHistory mainHistory;


### PR DESCRIPTION
This patch enforces that NNUE evaluation is used for endgame positions at shallow depth (depth <= 9).
Classic evaluation will still be used for high imbalance positions when the depth is high or there are many pieces.

Passed STC:
https://tests.stockfishchess.org/tests/view/624c193b3a8a6ac93892dc27
LLR: 2.94 (-2.94,2.94) <0.00,2.50>
Total: 255840 W: 68024 L: 67362 D: 120454
Ptnml(0-2): 1074, 27089, 70926, 27763, 1068

Passed LTC:
https://tests.stockfishchess.org/tests/view/624e8675e9e7821808467f77
LLR: 2.94 (-2.94,2.94) <0.50,3.00>
Total: 67088 W: 17784 L: 17454 D: 31850
Ptnml(0-2): 45, 6209, 20715, 6521, 54

closes https://github.com/official-stockfish/Stockfish/pull/3978

bench: 6602222