### PR TITLE
Simplify reduction condition for cutNodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1156,7 +1156,7 @@ moves_loop: // When in check, search starts here
               r--;
 
           // Increase reduction for cut nodes (~3 Elo)
-          if (cutNode && move != ss->killers[0])
+          if (cutNode)
               r += 2;
 
           // Increase reduction if ttMove is a capture (~3 Elo)


### PR DESCRIPTION
LMR: for cutNodes, dont exclude killer moves. This was a prelude to reducing
allNodes, altho that's failed so far.

STC https://tests.stockfishchess.org/tests/view/62d64ad147ae1768b34a27c3
LLR: 2.95 (-2.94,2.94) <-2.25,0.25>
Total: 37064 W: 10044 L: 9889 D: 17131
Ptnml(0-2): 162, 4115, 9828, 4260, 167

LTC https://tests.stockfishchess.org/tests/view/62d66cc047ae1768b34a2b14
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 39832 W: 10796 L: 10659 D: 18377
Ptnml(0-2): 69, 3969, 11706, 4100, 72

closes https://github.com/official-stockfish/Stockfish/pull/4109

bench: 5697891